### PR TITLE
Fix SSH Bottleneck

### DIFF
--- a/internal/ossh/config.go
+++ b/internal/ossh/config.go
@@ -31,6 +31,7 @@ func (c *OmniSSHConfig) Stream() (*StreamCycle, error) {
 	// TODO: There is a choke point here when a host does not connect. It waits until the SSH timeout before continuing.
 	ss := newStreamCycle(c.StreamChan, len(c.Config.Hosts))
 
+	log.OmniLog.Info("Returning StreamCycle")
 	return ss, nil
 }
 

--- a/internal/ossh/results.go
+++ b/internal/ossh/results.go
@@ -24,6 +24,7 @@ var (
 // back into the TodoHosts map once moved.
 type StreamCycle struct {
 	HostsResultChan chan massh.Result
+	NumHostsInit    int
 
 	// Lifecycle begin
 	TodoHosts map[string]struct{}
@@ -75,15 +76,15 @@ func (s *StreamCycle) isInitialised() bool {
 }
 
 func (s *StreamCycle) populateResultsMap(ch chan massh.Result, numHosts int) {
-	sent := 0
 	for {
 		select {
 		case result := <-ch:
 			s.HostsResultChan <- result
-			sent++
+			s.NumHostsInit++
 		default:
-			if sent == numHosts {
+			if s.NumHostsInit == numHosts {
 				log.OmniLog.Info(fmt.Sprintf("StreamCycle finished. HostsResultMap populated with a total of %d hosts.", numHosts))
+				return
 			}
 		}
 	}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -25,7 +25,7 @@ func MakeDP() {
 	DP.Group = group.NewValueGrouping()
 }
 
-func (data *Data) StartUI() {
+func (data *Data) StartUI(started chan struct{}) {
 	g, err := gocui.NewGui(gocui.OutputNormal)
 	if err != nil {
 		panic(err)
@@ -44,21 +44,31 @@ func (data *Data) StartUI() {
 		panic(err)
 	}
 
+	// Report that it's safe to refresh.
+	started <- struct{}{}
+
 	if err := data.UI.MainLoop(); err != nil && err != gocui.ErrQuit {
 		log.OmniLog.Fatal("Error")
 	}
+}
+
+func (data *Data) Close() {
+	data.UI.Close()
 }
 
 func (data *Data) Refresh() error {
 	data.UI.Update(func(g *gocui.Gui) error {
 		vw, err := g.View("output")
 		if err != nil {
+			return err
 		}
 
 		vw.Clear()
 
-		for k, v := range data.Group.EncodedValueGroup {
-			fmt.Fprintf(vw, "Hosts: %v\n\t Output: %s\n\n", v, data.Group.EncodedValueToOriginal[k])
+		if data.Group.EncodedValueGroup != nil {
+			for k, v := range data.Group.EncodedValueGroup {
+				fmt.Fprintf(vw, "Hosts: %v\n\t Output: %s\n\n", v, data.Group.EncodedValueToOriginal[k])
+			}
 		}
 
 		return nil
@@ -67,12 +77,15 @@ func (data *Data) Refresh() error {
 	data.UI.Update(func(g *gocui.Gui) error {
 		vw, err := g.View("todo")
 		if err != nil {
+			return err
 		}
 
 		vw.Clear()
 
-		for h := range data.StreamCycle.TodoHosts {
-			fmt.Fprintf(vw, "%s\n", h)
+		if data.StreamCycle.TodoHosts != nil {
+			for h := range data.StreamCycle.TodoHosts {
+				fmt.Fprintf(vw, "%s\n", h)
+			}
 		}
 
 		return nil
@@ -81,12 +94,15 @@ func (data *Data) Refresh() error {
 	data.UI.Update(func(g *gocui.Gui) error {
 		vw, err := g.View("complete")
 		if err != nil {
+			return err
 		}
 
 		vw.Clear()
 
-		for h := range data.StreamCycle.CompletedHosts {
-			fmt.Fprintf(vw, "%s\n", h)
+		if data.StreamCycle.CompletedHosts != nil {
+			for h := range data.StreamCycle.CompletedHosts {
+				fmt.Fprintf(vw, "%s\n", h)
+			}
 		}
 
 		return nil
@@ -95,12 +111,15 @@ func (data *Data) Refresh() error {
 	data.UI.Update(func(g *gocui.Gui) error {
 		vw, err := g.View("failed")
 		if err != nil {
+			return err
 		}
 
 		vw.Clear()
 
-		for h := range data.StreamCycle.FailedHosts {
-			fmt.Fprintf(vw, "%s\n", h)
+		if data.StreamCycle.FailedHosts != nil {
+			for h := range data.StreamCycle.FailedHosts {
+				fmt.Fprintf(vw, "%s\n", h)
+			}
 		}
 
 		return nil
@@ -109,12 +128,15 @@ func (data *Data) Refresh() error {
 	data.UI.Update(func(g *gocui.Gui) error {
 		vw, err := g.View("slow")
 		if err != nil {
+			return err
 		}
 
 		vw.Clear()
 
-		for h := range data.StreamCycle.SlowHosts {
-			fmt.Fprintf(vw, "%s\n", h)
+		if data.StreamCycle.SlowHosts != nil {
+			for h := range data.StreamCycle.SlowHosts {
+				fmt.Fprintf(vw, "%s\n", h)
+			}
 		}
 
 		return nil
@@ -175,7 +197,10 @@ func layout(g *gocui.Gui) error {
 }
 
 func update(g *gocui.Gui, v *gocui.View) error {
-	DP.Refresh()
+	err := DP.Refresh()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
* Fixes #4 
* Fixed SSH results block by switching HostResultsMap to HostResultsChan instead, to process results as they come in rather than waiting. 
* Also improved resiliency with UI starting procedure to prevent race condition and NPE. 